### PR TITLE
Provide web interface to run game without Pygame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # Mini Hero Quest
 
-This is a very small prototype inspired by **Hero Quest**. The board is a grid with corridors, traps, monsters and a treasure room. The hero moves by rolling a die and fights monsters using attack and defense dice.
+This is a very small prototype inspired by **Hero Quest**. The board is procedurally generated on each run with rooms connected by random corridors. Traps, monsters and the treasure room are placed at random locations. The hero moves by rolling a die and fights monsters using attack and defense dice. Combat results are written to `combat.log`.
 
 ## How to play
 
-1. Install dependencies (only pygame is required):
+1. Install dependencies:
    ```bash
-   pip install pygame
+   pip install -r requirements.txt
    ```
-2. Run the game:
+2. Run the original pygame version:
    ```bash
    python heroquest.py
    ```
+3. Or run the web version:
+   ```bash
+   python webquest.py
+   ```
+   Then open `http://localhost:8000` in your browser.
 
-Use the **SPACE** key to roll for movement. After rolling, move the hero with the arrow keys. Stepping on a monster tile starts a combat.
+In the pygame version, press **SPACE** to roll for movement and use the arrow keys to move. In the web version, use the buttons to roll and move. Stepping on a monster tile starts a combat.
 
 ### Combat rules
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pygame
+flask


### PR DESCRIPTION
## Summary
- add a simple Flask-based web version of the game
- document how to use the web version in the README
- include Flask in requirements

## Testing
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python heroquest.py & sleep 2; kill $!`
- `python webquest.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_685e82c27a7483218a043b623ba7bd23